### PR TITLE
Add hidden window spawned by Wox

### DIFF
--- a/applications.yaml
+++ b/applications.yaml
@@ -227,6 +227,14 @@
       comment: Targets copy/move operation windows
     - kind: title
       id: Control Panel
+- name: Wox
+  identifier:
+    kind: exe
+    id: Wox.exe
+  float_identifiers:
+    - kind: title
+      id: Hotkey sink
+      comment: Targets a hidden window spawned by Wox
 - name: Zoom
   identifier:
     kind: exe


### PR DESCRIPTION
[Wox is a FOSS desktop launcher similar to rofi on linux.](http://www.wox.one/)

I couldn't target window class because the string ends with a random GUID which changes after every app launch, so I targeted the window title. However, the window title is a bit generic which makes me a bit uneasy. I'm curious if targeting a window title that belongs to a process is in the plans?