### PR TITLE
Ignore hidden windows spawned by Firefox tab previews

### DIFF
--- a/applications.yaml
+++ b/applications.yaml
@@ -140,6 +140,10 @@
   options:
     - object_name_change
     - tray_and_multi_window
+  float_identifiers:
+    - kind: class
+      id: MozillaTaskbarPreviewClass
+      comment: Targets invisible windows spawned by Firefox to show tab previews in the taskbar
 - name: NiceHash Miner
   identifier:
     kind: exe


### PR DESCRIPTION
Adds a float rule for windows with class `MozillaTaskbarPreviewClass`.  These invisible windows are spawned by Firefox when its "Show tab previews in the Windows taskbar" option is enabled, presumably as a way to populate thumbnails for inactive tabs.  Komorebi will then try to tile these and make a mess of the layout.

The setting in question: 
![image](https://user-images.githubusercontent.com/6812901/177028530-1f990413-9ed5-4a5c-bdc3-c9faaaca8a90.png)
