### PR TITLE
fix(slack): update executable name

### DIFF
--- a/applications.yaml
+++ b/applications.yaml
@@ -455,6 +455,18 @@
   - kind: class
     id: Chrome_RenderWidgetHostHWND
     comment: Targets a hidden window spawned by Slack
+- name: Slack
+  identifier:
+    kind: exe
+    id: slack.exe
+  options:
+  - border_overflow
+  - force
+  - tray_and_multi_window
+  float_identifiers:
+  - kind: class
+    id: Chrome_RenderWidgetHostHWND
+    comment: Targets a hidden window spawned by Slack
 - name: Spotify
   identifier:
     kind: exe

--- a/applications.yaml
+++ b/applications.yaml
@@ -446,7 +446,7 @@
 - name: Slack
   identifier:
     kind: exe
-    id: slack.exe
+    id: Slack.exe
   options:
   - border_overflow
   - force


### PR DESCRIPTION
Capitalization thing. `slack.exe` is the bootstrapper, while `Slack.exe` is the actual application.