### PR TITLE
feat(apps): Add float rule for paint.net

### DIFF
--- a/applications.yaml
+++ b/applications.yaml
@@ -601,6 +601,13 @@
   float_identifiers:
   - kind: exe
     id: Zoom.exe
+- name: paint.net
+  identifier:
+    kind: exe
+    id: paintdotnet.exe
+  float_identifiers:
+  - kind: exe
+    id: paintdotnet.exe
 - name: qBittorrent
   identifier:
     kind: exe


### PR DESCRIPTION
paint.net uses multiple windows within the app, which breaks when attempting to tile.