### PR TITLE
chore(wingetui): add additional executable name

### DIFF
--- a/applications.yaml
+++ b/applications.yaml
@@ -586,6 +586,12 @@
     id: WingetUI.exe
   options:
   - tray_and_multi_window
+- name: WingetUI
+  identifier:
+    kind: exe
+    id: wingetui.exe
+  options:
+  - tray_and_multi_window
 - name: Wox
   identifier:
     kind: exe


### PR DESCRIPTION
WingetUI executable name became lowercase in the latest update
