### PR TITLE
chore: add overrides.yaml to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+overrides.yaml


### PR DESCRIPTION
Useful when you have `overrides.yaml` in the directory
