### PR TITLE
feat(apps): add WinZip

### DIFF
--- a/applications.yaml
+++ b/applications.yaml
@@ -840,7 +840,13 @@
   identifier:
     kind: exe
     id: winzip64.exe
+  float_identifiers:
+  - kind: exe
+    id: winzip64.exe
 - name: WinZip (32-bit)
   identifier:
     kind: exe
+    id: winzip32.exe
+  float_identifiers:
+  - kind: exe
     id: winzip32.exe

--- a/applications.yaml
+++ b/applications.yaml
@@ -836,11 +836,11 @@
   float_identifiers:
   - kind: exe
     id: ueli.exe
-- name: Winzip (64-bit)
+- name: WinZip (64-bit)
   identifier:
     kind: exe
     id: winzip64.exe
-- name: Winzip (32-bit)
+- name: WinZip (32-bit)
   identifier:
     kind: exe
     id: winzip32.exe

--- a/applications.yaml
+++ b/applications.yaml
@@ -836,3 +836,11 @@
   float_identifiers:
   - kind: exe
     id: ueli.exe
+- name: Winzip (64-bit)
+  identifier:
+    kind: exe
+    id: winzip64.exe
+- name: Winzip (32-bit)
+  identifier:
+    kind: exe
+    id: winzip32.exe

--- a/applications.yaml
+++ b/applications.yaml
@@ -745,6 +745,20 @@
     id: WebTorrent.exe
   options:
   - tray_and_multi_window
+- name: WinZip (32-bit)
+  identifier:
+    kind: exe
+    id: winzip32.exe
+  float_identifiers:
+  - kind: exe
+    id: winzip32.exe
+- name: WinZip (64-bit)
+  identifier:
+    kind: exe
+    id: winzip64.exe
+  float_identifiers:
+  - kind: exe
+    id: winzip64.exe
 - name: Windows Console (conhost.exe)
   identifier:
     kind: class
@@ -836,17 +850,3 @@
   float_identifiers:
   - kind: exe
     id: ueli.exe
-- name: WinZip (64-bit)
-  identifier:
-    kind: exe
-    id: winzip64.exe
-  float_identifiers:
-  - kind: exe
-    id: winzip64.exe
-- name: WinZip (32-bit)
-  identifier:
-    kind: exe
-    id: winzip32.exe
-  float_identifiers:
-  - kind: exe
-    id: winzip32.exe


### PR DESCRIPTION
Added entries for WinZip 64-bit and 32-bit exe files to treat them as floating applications.

- [ ] I have formatted `applications.yaml` with `komorebic fmt-asc`.

Note: Since I use komorebi on my work laptop, I couldn't use that to raise this PR due to organization policy and had to use my Mac to raise this PR, which is why I was unable to run the formatter.