### PR TITLE
fix(steambeta;signal): Fixed Signal.exe case sensitivity. Only the main Steam window will now get managed

### DIFF
--- a/applications.yaml
+++ b/applications.yaml
@@ -630,7 +630,7 @@
 - name: Signal
   identifier:
     kind: exe
-    id: signal.exe
+    id: Signal.exe
   options:
   - tray_and_multi_window
 - name: SiriKali

--- a/applications.yaml
+++ b/applications.yaml
@@ -709,7 +709,6 @@
     id: notificationtoasts_
     comment: Target notification toast popups
 - name: Steam Beta - float_rule
-    comment: Comment the next section out if you want all Steam windows to tile
   identifier:
     kind: title
     id: Steam

--- a/applications.yaml
+++ b/applications.yaml
@@ -693,11 +693,15 @@
   - border_overflow
 - name: Steam Beta
   identifier:
-    kind: class
-    id: SDL_app
+    kind: title
+    id: Steam
   options:
+  - force
   - border_overflow
   - tray_and_multi_window
+  float_identifiers:
+  - kind: exe
+    id: steamwebhelper.exe
 - name: Stremio
   identifier:
     kind: exe

--- a/applications.yaml
+++ b/applications.yaml
@@ -28,6 +28,15 @@
     id: Photoshop
   options:
   - border_overflow
+- name: Affinity Photo 2
+  identifier:
+    kind: title
+    id: Affinity Photo 2
+  options:
+  - force
+  float_identifiers:
+  - kind: exe
+    id: Photo.exe
 - name: Akiflow
   identifier:
     kind: exe

--- a/applications.yaml
+++ b/applications.yaml
@@ -693,12 +693,17 @@
   - border_overflow
 - name: Steam Beta
   identifier:
+    kind: class
+    id: SDL_app
+  options:
+  - border_overflow
+  - tray_and_multi_window
+- name: Steam Beta - floating rules
+  identifier:
     kind: title
     id: Steam
   options:
   - force
-  - border_overflow
-  - tray_and_multi_window
   float_identifiers:
   - kind: exe
     id: steamwebhelper.exe

--- a/applications.yaml
+++ b/applications.yaml
@@ -698,7 +698,7 @@
   options:
   - border_overflow
   - tray_and_multi_window
-- name: Steam Beta - floating rules
+- name: Steam Beta - float_rule
   identifier:
     kind: title
     id: Steam


### PR DESCRIPTION
Makes only the main Steam window tile. Also fixes a quirk, where the "Your friend is now playing..." window would re-tile the screen.
Fixes Signal.exe not closing properly.

- [x] I have formatted `applications.yaml` with `komorebic fmt-asc`.