### PR TITLE
feat(apps): add Mattermost

### DIFF
--- a/applications.yaml
+++ b/applications.yaml
@@ -431,6 +431,13 @@
   options:
   - border_overflow
   - tray_and_multi_window
+- name: Mattermost
+  identifier:
+    kind: Exe
+    id: Mattermost.exe
+  options:
+  - border_overflow
+  - tray_and_multi_window
 - name: Mica For Everyone
   identifier:
     kind: Exe


### PR DESCRIPTION
<!--
  Please follow the Conventional Commits specification.
  By opening this PR, you confirm that you have already searched for similar existing issues/PRs.
  Provide a general summary of your changes below and tick the boxes that apply to the checklist.
-->

Mattermost (an Electron-based chat app, like Discord/Slack) was missing. From my quick testing adding this here resolves it. 

- [x] I have formatted `applications.yaml` with `komorebic fmt-asc`.