### PR TITLE
Identify floating windows in ShareX

### DIFF
--- a/applications.yaml
+++ b/applications.yaml
@@ -929,6 +929,10 @@
   options:
   - border_overflow
   - tray_and_multi_window
+  float_identifiers:
+  - kind: Title
+    id: ShareX -
+    comment: Popup windows seems to start with this
 - name: Sideloadly
   identifier:
     kind: Exe


### PR DESCRIPTION
This is an attempt to allow floating windows, with the existing ShareX entry

- [X] I have formatted `applications.yaml` with `komorebic fmt-asc`.