### PR TITLE
Add Cider border overflow rule

### DIFF
--- a/applications.yaml
+++ b/applications.yaml
@@ -124,6 +124,13 @@
   float_identifiers:
   - kind: Title
     id: Calculator
+- name: Cider
+  identifier:
+    kind: Title
+    id: Cider ?2?
+    matching_strategy: Regex
+  options:
+  - border_overflow
 - name: Citrix Receiver
   identifier:
     kind: Exe


### PR DESCRIPTION
Had to do some regex (yay for being able to do that now!) because apparently the window loves renaming itself between Cider and Cider 2, seemingly at random, but I have double checked with the old version of Cider and doing this doesn't mess that version up, so while not elegant, it does work.

Also the mini player straight up does not work as intended, as I can only find a way to target it by title (both the class and exe are a generic Electron one).

It's far from perfect, but at least the borders are fixed, which is better than having them not be fixed.

<!--
  Please follow the Conventional Commits specification.
  By opening this PR, you confirm that you have already searched for similar existing issues/PRs.
  Provide a general summary of your changes below and tick the boxes that apply to the checklist.
-->

- [x] I have formatted `applications.yaml` with `komorebic fmt-asc`.