### PR TITLE
Explicitly set `matching_strategies` if unspecified

### DIFF
--- a/applications.yaml
+++ b/applications.yaml
@@ -15,33 +15,40 @@
   float_identifiers:
   - kind: Exe
     id: 1Password.exe
+    matching_strategy: Equals
 - name: Ableton Live
   identifier:
     kind: Class
     id: Ableton Live Window Class
+    matching_strategy: Legacy
   float_identifiers:
   - kind: Class
     id: AbletonVstPlugClass
     comment: Targets VST2 windows
+    matching_strategy: Legacy
   - kind: Class
     id: Vst3PlugWindow
     comment: Targets VST3 windows
+    matching_strategy: Legacy
 - name: Adobe Creative Cloud
   identifier:
     kind: Class
     id: CreativeCloudDesktopWindowClass
+    matching_strategy: Legacy
   options:
   - tray_and_multi_window
 - name: Adobe Photoshop
   identifier:
     kind: Class
     id: Photoshop
+    matching_strategy: Legacy
   options:
   - border_overflow
 - name: Adobe Premiere Pro
   identifier:
     kind: Class
     id: Premiere Pro
+    matching_strategy: Legacy
   float_identifiers:
   - kind: Class
     id: DroverLord - Window Class
@@ -51,11 +58,13 @@
   identifier:
     kind: Title
     id: Affinity Photo 2
+    matching_strategy: Legacy
   options:
   - force
   float_identifiers:
   - kind: Exe
     id: Photo.exe
+    matching_strategy: Equals
 - name: Akiflow
   identifier:
     kind: Exe
@@ -95,8 +104,10 @@
   float_identifiers:
   - kind: Title
     id: Window Spy
+    matching_strategy: Legacy
   - kind: Exe
     id: AutoHotkeyUX.exe
+    matching_strategy: Equals
 - name: Beeper
   identifier:
     kind: Exe
@@ -128,6 +139,7 @@
   float_identifiers:
   - kind: Exe
     id: Bloxstrap.exe
+    matching_strategy: Equals
 - name: Brave Browser
   identifier:
     kind: Exe
@@ -139,9 +151,11 @@
   identifier:
     kind: Title
     id: Calculator
+    matching_strategy: Legacy
   float_identifiers:
   - kind: Title
     id: Calculator
+    matching_strategy: Legacy
 - name: Citrix Receiver
   identifier:
     kind: Exe
@@ -152,6 +166,7 @@
   float_identifiers:
   - kind: Exe
     id: SelfService.exe
+    matching_strategy: Equals
 - name: Clash Verge
   identifier:
     kind: Exe
@@ -183,6 +198,7 @@
   - kind: Exe
     id: CredentialUIBroker.exe
     comment: Targets the Windows popup prompting you for a PIN instead of a password on 1Password etc.
+    matching_strategy: Equals
 - name: Cron
   identifier:
     kind: Exe
@@ -202,13 +218,16 @@
   identifier:
     kind: Class
     id: TApplication
+    matching_strategy: Legacy
   float_identifiers:
   - kind: Class
     id: TApplication
     comment: Target hidden window spawned by Delphi applications
+    matching_strategy: Legacy
   - kind: Class
     id: TWizardForm
     comment: Target Inno Setup installers
+    matching_strategy: Legacy
 - name: Discord
   identifier:
     kind: Exe
@@ -257,6 +276,7 @@
   float_identifiers:
   - kind: Exe
     id: Dropbox.exe
+    matching_strategy: Equals
 - name: EA Desktop Client
   identifier:
     kind: Exe
@@ -293,6 +313,7 @@
   float_identifiers:
   - kind: Exe
     id: Elephicon.exe
+    matching_strategy: Equals
 - name: ElevenClock
   identifier:
     kind: Exe
@@ -308,6 +329,7 @@
   float_identifiers:
   - kind: Exe
     id: Camera Hub.exe
+    matching_strategy: Equals
 - name: Elgato Control Center
   identifier:
     kind: Exe
@@ -316,6 +338,7 @@
   float_identifiers:
   - kind: Exe
     id: ControlCenter.exe
+    matching_strategy: Equals
 - name: Elgato Wave Link
   identifier:
     kind: Exe
@@ -324,6 +347,7 @@
   float_identifiers:
   - kind: Exe
     id: WaveLink.exe
+    matching_strategy: Equals
 - name: Epic Games Launcher
   identifier:
     kind: Exe
@@ -336,12 +360,14 @@
   identifier:
     kind: Class
     id: EVERYTHING
+    matching_strategy: Legacy
   options:
   - tray_and_multi_window
 - name: Everything1.5a
   identifier:
     kind: Class
     id: EVERYTHING_(1.5a)
+    matching_strategy: Legacy
   options:
   - force
   - tray_and_multi_window
@@ -386,10 +412,12 @@
   - kind: Class
     id: Chrome_RenderWidgetHostHWND
     comment: Targets a hidden window spawned by GOG Galaxy
+    matching_strategy: Legacy
 - name: GoPro Webcam
   identifier:
     kind: Class
     id: GoPro Webcam
+    matching_strategy: Legacy
   options:
   - tray_and_multi_window
 - name: Godot Manager
@@ -425,10 +453,12 @@
   float_identifiers:
   - kind: Exe
     id: GoogleDriveFS.exe
+    matching_strategy: Equals
 - name: Honeyview
   identifier:
     kind: Class
     id: HoneyviewClassX
+    matching_strategy: Legacy
   options:
   - border_overflow
 - name: Houdoku
@@ -450,6 +480,7 @@
   - kind: Class
     id: SunAwtDialog
     comment: Targets JetBrains IDE popups and floating windows
+    matching_strategy: Legacy
 - name: Itch.io
   identifier:
     kind: Exe
@@ -473,6 +504,7 @@
   float_identifiers:
   - kind: Exe
     id: keyviz.exe
+    matching_strategy: Equals
 - name: Kleopatra
   identifier:
     kind: Exe
@@ -503,6 +535,7 @@
   float_identifiers:
   - kind: Exe
     id: LogiBolt.exe
+    matching_strategy: Equals
 - name: LogiTune
   identifier:
     kind: Exe
@@ -513,6 +546,7 @@
   float_identifiers:
   - kind: Exe
     id: LogiTune.exe
+    matching_strategy: Equals
 - name: Logitech G HUB
   identifier:
     kind: Exe
@@ -529,6 +563,7 @@
   float_identifiers:
   - kind: Exe
     id: LogiOptionsUI.exe
+    matching_strategy: Equals
 - name: Mailspring
   identifier:
     kind: Exe
@@ -571,10 +606,12 @@
   identifier:
     kind: Class
     id: ''
+    matching_strategy: Legacy
   float_identifiers:
   - kind: Class
     id: '#32770'
     comment: Dialog Box
+    matching_strategy: Legacy
 - name: Microsoft Excel
   identifier:
     kind: Exe
@@ -587,6 +624,7 @@
   - kind: Class
     id: _WwB
     comment: Targets a hidden window spawned by Microsoft Office applications
+    matching_strategy: Legacy
 - name: Microsoft Outlook
   identifier:
     kind: Exe
@@ -600,6 +638,7 @@
   - kind: Class
     id: _WwB
     comment: Targets a hidden window spawned by Microsoft Office applications
+    matching_strategy: Legacy
 - name: Microsoft PC Manager
   identifier:
     kind: Exe
@@ -608,6 +647,7 @@
   float_identifiers:
   - kind: Exe
     id: MSPCManager.exe
+    matching_strategy: Equals
 - name: Microsoft PowerPoint
   identifier:
     kind: Exe
@@ -620,10 +660,12 @@
   - kind: Class
     id: _WwB
     comment: Targets a hidden window spawned by Microsoft Office applications
+    matching_strategy: Legacy
 - name: Microsoft Teams
   identifier:
     kind: Class
     id: TeamsWebView
+    matching_strategy: Legacy
   options:
   - tray_and_multi_window
 - name: Microsoft Teams classic
@@ -637,9 +679,11 @@
   - kind: Title
     id: Microsoft Teams Notification
     comment: Target Teams pop-up notification windows
+    matching_strategy: Legacy
   - kind: Title
     id: Microsoft Teams Call
     comment: Target Teams call in progress windows
+    matching_strategy: Legacy
 - name: Microsoft Word
   identifier:
     kind: Exe
@@ -652,6 +696,7 @@
   - kind: Class
     id: _WwB
     comment: Targets a hidden window spawned by Microsoft Office applications
+    matching_strategy: Legacy
 - name: Modern Flyouts
   identifier:
     kind: Exe
@@ -671,6 +716,7 @@
   - kind: Class
     id: MozillaTaskbarPreviewClass
     comment: Targets invisible windows spawned by Firefox to show tab previews in the taskbar
+    matching_strategy: Legacy
 - name: NVIDIA GeForce Experience
   identifier:
     kind: Exe
@@ -708,6 +754,7 @@
   float_identifiers:
   - kind: Exe
     id: NohBoard.exe
+    matching_strategy: Equals
 - name: Notion Enhanced
   identifier:
     kind: Exe
@@ -734,6 +781,7 @@
   identifier:
     kind: Class
     id: DocEditorsWindowClass
+    matching_strategy: Legacy
   options:
   - border_overflow
   - tray_and_multi_window
@@ -753,6 +801,7 @@
   float_identifiers:
   - kind: Class
     id: OneDriveReactNativeWin32WindowClass
+    matching_strategy: Legacy
 - name: OneQuick
   identifier:
     kind: Exe
@@ -775,6 +824,7 @@
   float_identifiers:
   - kind: Exe
     id: Paradox Launcher.exe
+    matching_strategy: Equals
 - name: Passware Kit Forensic
   identifier:
     kind: Exe
@@ -794,6 +844,7 @@
   - kind: Exe
     id: Playnite.FullscreenApp.exe
     comment: Target fullscreen app
+    matching_strategy: Equals
 - name: Plexamp
   identifier:
     kind: Exe
@@ -810,15 +861,19 @@
   - kind: Exe
     id: PowerToys.ColorPickerUI.exe
     comment: Target color picker dialog
+    matching_strategy: Equals
   - kind: Exe
     id: PowerToys.CropAndLock.exe
     comment: Target thumbnail/cropped window
+    matching_strategy: Equals
   - kind: Exe
     id: PowerToys.ImageResizer.exe
     comment: Target image resizer dialog
+    matching_strategy: Equals
   - kind: Exe
     id: PowerToys.Peek.UI.exe
     comment: Target Peek popup
+    matching_strategy: Equals
   - kind: Exe
     id: PowerToys.PowerLauncher.exe
     comment: PpowerLauncher popup
@@ -833,6 +888,7 @@
   float_identifiers:
   - kind: Exe
     id: ProcessHacker.exe
+    matching_strategy: Equals
 - name: ProtonDrive
   identifier:
     kind: Exe
@@ -861,6 +917,7 @@
   - kind: Class
     id: SunAwtDialog
     comment: Targets JetBrains IDE popups and detached windows
+    matching_strategy: Legacy
 - name: QQ
   identifier:
     kind: Exe
@@ -871,10 +928,13 @@
   float_identifiers:
   - kind: Title
     id: 图片查看器
+    matching_strategy: Legacy
   - kind: Title
     id: 群聊的聊天记录
+    matching_strategy: Legacy
   - kind: Title
     id: 语音通话
+    matching_strategy: Legacy
 - name: QtScrcpy
   identifier:
     kind: Exe
@@ -890,6 +950,7 @@
   float_identifiers:
   - kind: Exe
     id: QuickLook.exe
+    matching_strategy: Equals
 - name: RepoZ
   identifier:
     kind: Exe
@@ -898,6 +959,7 @@
   float_identifiers:
   - kind: Exe
     id: RepoZ.exe
+    matching_strategy: Equals
 - name: Rider
   identifier:
     kind: Exe
@@ -910,9 +972,11 @@
   - kind: Class
     id: SunAwtDialog
     comment: Targets JetBrains IDE popups and floating windows
+    matching_strategy: Legacy
   - kind: Title
     id: PopupMessageWindow
     comment: Targets JetBrains IDE popups
+    matching_strategy: Legacy
 - name: Roblox FPS Unlocker
   identifier:
     kind: Exe
@@ -928,6 +992,7 @@
   float_identifiers:
   - kind: Exe
     id: RoundedTB.exe
+    matching_strategy: Equals
 - name: RoundedTB
   identifier:
     kind: Exe
@@ -948,6 +1013,7 @@
   - kind: Class
     id: SunAwtDialog
     comment: Targets JetBrains IDE popups and floating windows
+    matching_strategy: Legacy
 - name: Sandboxie Plus
   identifier:
     kind: Exe
@@ -971,6 +1037,7 @@
   float_identifiers:
   - kind: Exe
     id: sideloadly.exe
+    matching_strategy: Equals
 - name: Signal
   identifier:
     kind: Exe
@@ -997,6 +1064,7 @@
   - kind: Class
     id: Chrome_RenderWidgetHostHWND
     comment: Targets a hidden window spawned by Slack
+    matching_strategy: Legacy
 - name: Slack
   identifier:
     kind: Exe
@@ -1009,6 +1077,7 @@
   - kind: Class
     id: Chrome_RenderWidgetHostHWND
     comment: Targets a hidden window spawned by Slack
+    matching_strategy: Legacy
 - name: Smart Install Maker
   identifier:
     kind: Exe
@@ -1018,9 +1087,11 @@
   - kind: Class
     id: obj_App
     comment: Target hidden window spawned by installer
+    matching_strategy: Legacy
   - kind: Class
     id: obj_Form
     comment: Target installer
+    matching_strategy: Legacy
 - name: SnippingTool
   identifier:
     kind: Exe
@@ -1029,6 +1100,7 @@
   float_identifiers:
   - kind: Exe
     id: SnippingTool.exe
+    matching_strategy: Equals
 - name: SoulseekQt
   identifier:
     kind: Exe
@@ -1048,12 +1120,14 @@
   identifier:
     kind: Class
     id: vguiPopupWindow
+    matching_strategy: Legacy
   options:
   - border_overflow
 - name: Steam Beta
   identifier:
     kind: Class
     id: SDL_app
+    matching_strategy: Legacy
   options:
   - border_overflow
   - tray_and_multi_window
@@ -1061,6 +1135,7 @@
   - kind: Title
     id: notificationtoasts_
     comment: Target notification toast popups
+    matching_strategy: Legacy
 - name: Stremio
   identifier:
     kind: Exe
@@ -1078,6 +1153,7 @@
   float_identifiers:
   - kind: Exe
     id: SystemInformer.exe
+    matching_strategy: Equals
 - name: SystemSettings
   identifier:
     kind: Exe
@@ -1086,6 +1162,7 @@
   float_identifiers:
   - kind: Class
     id: Shell_Dialog
+    matching_strategy: Legacy
 - name: Task Manager
   identifier:
     kind: Exe
@@ -1094,6 +1171,7 @@
   float_identifiers:
   - kind: Class
     id: TaskManagerWindow
+    matching_strategy: Legacy
 - name: Telegram
   identifier:
     kind: Exe
@@ -1120,6 +1198,7 @@
   float_identifiers:
   - kind: Exe
     id: tcconfig.exe
+    matching_strategy: Equals
 - name: TranslucentTB
   identifier:
     kind: Exe
@@ -1128,6 +1207,7 @@
   float_identifiers:
   - kind: Exe
     id: TranslucentTB.exe
+    matching_strategy: Equals
 - name: TranslucentTB
   identifier:
     kind: Exe
@@ -1209,6 +1289,7 @@
   float_identifiers:
   - kind: Exe
     id: winzip32.exe
+    matching_strategy: Equals
 - name: WinZip (64-bit)
   identifier:
     kind: Exe
@@ -1217,10 +1298,12 @@
   float_identifiers:
   - kind: Exe
     id: winzip64.exe
+    matching_strategy: Equals
 - name: Windows Console (conhost.exe)
   identifier:
     kind: Class
     id: ConsoleWindowClass
+    matching_strategy: Legacy
   options:
   - force
 - name: Windows Explorer
@@ -1232,8 +1315,10 @@
   - kind: Class
     id: OperationStatusWindow
     comment: Targets copy/move operation windows
+    matching_strategy: Legacy
   - kind: Title
     id: Control Panel
+    matching_strategy: Legacy
 - name: Windows Installer
   identifier:
     kind: Exe
@@ -1242,6 +1327,7 @@
   float_identifiers:
   - kind: Exe
     id: msiexec.exe
+    matching_strategy: Equals
 - name: Windows Subsystem for Android
   identifier:
     kind: Exe
@@ -1251,6 +1337,7 @@
   - kind: Class
     id: android(splash)
     comment: Targets splash/startup screen
+    matching_strategy: Legacy
 - name: WingetUI
   identifier:
     kind: Exe
@@ -1274,6 +1361,7 @@
   - kind: Title
     id: Hotkey sink
     comment: Targets a hidden window spawned by Wox
+    matching_strategy: Legacy
 - name: XAMPP Control Panel
   identifier:
     kind: Exe
@@ -1289,10 +1377,12 @@
   float_identifiers:
   - kind: Exe
     id: Zoom.exe
+    matching_strategy: Equals
 - name: mpv
   identifier:
     kind: Class
     id: mpv
+    matching_strategy: Legacy
   options:
   - object_name_change
 - name: mpv.net
@@ -1310,6 +1400,7 @@
   float_identifiers:
   - kind: Exe
     id: paintdotnet.exe
+    matching_strategy: Equals
 - name: pinentry
   identifier:
     kind: Exe
@@ -1318,6 +1409,7 @@
   float_identifiers:
   - kind: Exe
     id: pinentry.exe
+    matching_strategy: Equals
 - name: qBittorrent
   identifier:
     kind: Exe
@@ -1335,3 +1427,4 @@
   float_identifiers:
   - kind: Exe
     id: ueli.exe
+    matching_strategy: Equals


### PR DESCRIPTION
This adds `matching_strategy` to all `identifier` and `float_identifiers` that currently do not explicitly specify it. In each of these cases, the matcher is set to the current Komorebi default values: `Equals` for `Exe`; `Legacy` for `Class` and `Title`. 

This paths the way to a future enforcing of an explicit matcher for each rule. Moreover, by making all implicit uses of `Legacy` explicit, this PR enables future PRs that scrutinize each `Legacy` rule, replacing them with a more appropriate choice of `Equals`, `StartsWith` or `EndsWith`. In that, it helps moving towards an eventual depreciation of `Legacy` as the default.
