### PR TITLE
feat(apps): remove border_overflow from OUTLOOK.exe

### DIFF
--- a/applications.yaml
+++ b/applications.yaml
@@ -648,7 +648,6 @@
     id: OUTLOOK.EXE
     matching_strategy: Equals
   options:
-  - border_overflow
   - layered
   - tray_and_multi_window
   float_identifiers:


### PR DESCRIPTION
- [x] I have formatted `applications.yaml` with `komorebic fmt-asc`.

Border overflow seems to not be needed on MS Outlook anymore.