### PR TITLE
feat(applications): add MaxxAudioPro

### DIFF
--- a/applications.yaml
+++ b/applications.yaml
@@ -588,6 +588,17 @@
     matching_strategy: Equals
   options:
   - tray_and_multi_window
+- name: MaxxAudioPro
+  identifier:
+    kind: Title
+    id: MaxxAudioPro
+    matching_strategy: Equals
+  options:
+  - tray_and_multi_window
+  float_identifiers:
+  - kind: Title
+    id: MaxxAudioPro
+    matching_strategy: Equals
 - name: Mica For Everyone
   identifier:
     kind: Exe

--- a/applications.yaml
+++ b/applications.yaml
@@ -590,11 +590,9 @@
   - tray_and_multi_window
 - name: MaxxAudioPro
   identifier:
-    kind: Title
-    id: MaxxAudioPro
+    kind: Exe
+    id: ApplicationFrameHost.exe
     matching_strategy: Equals
-  options:
-  - tray_and_multi_window
   float_identifiers:
   - kind: Title
     id: MaxxAudioPro


### PR DESCRIPTION
<!--
  Please follow the Conventional Commits specification.
  By opening this PR, you confirm that you have already searched for similar existing issues/PRs.
  Provide a general summary of your changes below and tick the boxes that apply to the checklist.
-->

- [x] I have formatted `applications.yaml` with `komorebic fmt-asc`.

---

Hi. I have added `MaxxAudioPro` _(which is usually installed on Dell machines to handle audio drivers or something)_.

In this case, whenever I plug in an earphone/headphone/microphone, there will be a pop-up window to select which device is plugged in.

![https://github.com/LGUG2Z/komorebi-application-specific-configuration/assets/86353526/23483945-9ad2-4316-8b02-40641d3abe5e](https://github.com/LGUG2Z/komorebi-application-specific-configuration/assets/86353526/23483945-9ad2-4316-8b02-40641d3abe5e)

Thank you, guys, the maintainers, for considering this PR.
