### PR TITLE
Viture Spacewalker app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 overrides.yaml
+/.vscode

--- a/applications.yaml
+++ b/applications.yaml
@@ -1453,3 +1453,13 @@
   - kind: Exe
     id: ueli.exe
     matching_strategy: Equals
+- name: SpaceWalker.Desktop
+  Identifier:
+    kind: Exe
+    id: SpaceWalker.Desktop.exe
+    matching_strategy: Equals
+- name: SpaceWalker.Unity.exe
+  Identifier:
+    kind: Exe
+    id: SpaceWalker.Unity.exe
+    matching_strategy: Equals

--- a/applications.yaml
+++ b/applications.yaml
@@ -1090,6 +1090,16 @@
     matching_strategy: Equals
   options:
   - tray_and_multi_window
+- name: SpaceWalker.Desktop
+  identifier:
+    kind: Exe
+    id: SpaceWalker.Desktop.exe
+    matching_strategy: Equals
+- name: SpaceWalker.Unity.exe
+  identifier:
+    kind: Exe
+    id: SpaceWalker.Unity.exe
+    matching_strategy: Equals
 - name: Spotify
   identifier:
     kind: Exe
@@ -1452,14 +1462,4 @@
   float_identifiers:
   - kind: Exe
     id: ueli.exe
-    matching_strategy: Equals
-- name: SpaceWalker.Desktop
-  Identifier:
-    kind: Exe
-    id: SpaceWalker.Desktop.exe
-    matching_strategy: Equals
-- name: SpaceWalker.Unity.exe
-  Identifier:
-    kind: Exe
-    id: SpaceWalker.Unity.exe
     matching_strategy: Equals


### PR DESCRIPTION
[Viture](https://www.viture.com/) have today released [SpaceWalker](https://academy.viture.com/xr_glasses/spacewalker_windows) for windows, which allows the glasses to use 3 virtual displays. 

 Unfortunately, they implement the 3 degrees of freedom 3-virtual-display mode as a window in a fourth monitor, which gets managed by komorebi which causes them to get wedged.  

This seems to fix that problem.

- [x] I have formatted `applications.yaml` with `komorebic fmt-asc`.