### PR TITLE
add float_rule for Amazon Chime and Core Temp

### DIFF
--- a/applications.yaml
+++ b/applications.yaml
@@ -80,6 +80,15 @@
     matching_strategy: Equals
   options:
   - tray_and_multi_window
+- name: Amazon Chime
+  identifier:
+    kind: Exe
+    id: Chime.exe
+    matching_strategy: Equals
+  float_identifiers:
+  - kind: Title
+    id: Meeting Controls
+    matching_strategy: EndsWith
 - name: Android Studio
   identifier:
     kind: Exe
@@ -205,6 +214,15 @@
     matching_strategy: Equals
   options:
   - tray_and_multi_window
+- name: Core Temp
+  identifier:
+    kind: Exe
+    id: Core Temp.exe
+    matching_strategy: Equals
+  float_identifiers:
+  - kind: Exe
+    id: Core Temp.exe
+    matching_strategy: Equals
 - name: Credential Manager UI Host
   identifier:
     kind: Exe


### PR DESCRIPTION
* For Amazon Chime: only ignore the Meeting Control pop-up, which is activated during an active call, when the user shifts the focused window to anything that's not that Amazon Chime meeting window. This pop-up needs to be ignored.
* For Core Temp: the GUI does not scale, thus should be ignored by komorebi (or kept as a floating window).

- [x] I have formatted `applications.yaml` with `komorebic fmt-asc`.