### PR TITLE
feat(applications): add AutoCAD and derivatives

### DIFF
--- a/applications.yaml
+++ b/applications.yaml
@@ -110,6 +110,24 @@
     matching_strategy: Equals
   options:
   - tray_and_multi_window
+- name: AutoDesk AutoCAD Suite
+  identifier:
+    kind: Exe
+    id: acad.exe
+    matching_strategy: Equals
+  float_identifiers:
+  - - kind: Class
+      id: 'Afx:'
+      matching_strategy: Contains
+    - kind: Exe
+      id: acad.exe
+      matching_strategy: Equals
+  - - kind: Class
+      id: HwndWrapper[DefaultDomain
+      matching_strategy: StartsWith
+    - kind: Exe
+      id: acad.exe
+      matching_strategy: Equals
 - name: AutoHotkey
   identifier:
     kind: Exe


### PR DESCRIPTION
Added programs known by their executable "acad.exe".

Tested by personal use in:
- Autodesk AutoCAD
- Autodesk Civil3D

<!--
  Please follow the Conventional Commits specification.
  By opening this PR, you confirm that you have already searched for similar existing issues/PRs.
  Provide a general summary of your changes below and tick the boxes that apply to the checklist.
-->

- [x] I have formatted `applications.yaml` with `komorebic fmt-asc`.