### PR TITLE
Added rules for Microsoft Visio

### DIFF
--- a/applications.yaml
+++ b/applications.yaml
@@ -1535,3 +1535,17 @@
   - kind: Exe
     id: ueli.exe
     matching_strategy: Equals
+- name: visio
+  identifier:
+    kind: Class
+    id: VISIOA
+    matching_strategy: Equals
+  options:
+  - force
+  float_identifiers:
+  - kind: Class
+    id: VISIOS
+    matching_strategy: Equals
+  - kind: Class
+    id: VISIOQ
+    matching_strategy: Equals


### PR DESCRIPTION
Added rules for Microsoft Visio to force management of the main application window (class `VISIOA`) and float/unmanage the windows within the main application window (this includes Document windows with class `VISIOA` and ShapeSheet Editor windows with class `VISIOQ`)

Please be aware that this has only been tested on the version of Visio bundled with Office 365 subscription. Older versions (2007/2010/2013/etc) might behave differently. Unfortunately I'm not sure any of those versions can be tested without a licensed install.  However, I'd speculate that the rules might work on those versions as well, given that the UI hasn't changed from a qualitative standpoint, and hasn't been rigorously overhauled like Microsoft's other Office 365 apps. If anyone out there is working on an older version of Visio, I'd appreciate some investigation with either the AutoHotkey Window Spy or `komorebic state`.

- [ X] I have formatted `applications.yaml` with `komorebic fmt-asc`.

Demonstration of Window Classes below. I outlined the main window in green and the windows within the window in red. This shows two document/drawing windows and one ShapeSheet Editor window.
![Visio_window_classes](https://github.com/user-attachments/assets/d2ce87a5-a9a2-4715-86d1-3c7f48bc2245)

This is what it looks like without the window rules set. Without the rules set, it seems the windows (red) within the main window (green) are automatically tiled outside of the main window and thus out of view. Pardon the aspect ratio 😎. As for the position/size of the ShapeSheet Editor window, my only explanation can be that Visio's built in features (i.e., Window --> Arrange All, etc) will fight Komorebi. If I drag the shapesheet window, Komorebi will interpret it as it would any other window being dragged over a container.
![Visio_without_rules_set](https://github.com/user-attachments/assets/f80e4048-48ae-418c-b073-4d36f1cea19e)
