### PR TITLE
Add transparency and multi window rules for Unity Engine

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1678,6 +1678,13 @@
         "id": "Unity.exe",
         "matching_strategy": "Equals"
       }
+    ],
+    "tray_and_multi_window": [
+      {
+        "kind": "Exe",
+        "id": "Unity.exe",
+        "matching_strategy": "Equals"
+      }
     ]
   },
   "Unity Hub": {

--- a/applications.json
+++ b/applications.json
@@ -1671,6 +1671,15 @@
       }
     ]
   },
+  "Unity Editor": {
+    "transparency_ignore": [
+      {
+        "kind": "Exe",
+        "id": "Unity.exe",
+        "matching_strategy": "Equals"
+      }
+    ]
+  },
   "Unity Hub": {
     "tray_and_multi_window": [
       {


### PR DESCRIPTION
- [ ] I have formatted `applications.yaml` with `komorebic fmt-asc`.

Hello again!

Here is the PR that makes Unity Editor ignore transparency. 

When testing this I realized I'm still on Komorebi 1.29 so I had to upgrade to 1.30. This then had me discover an issue with Unity creating a console window that get's minimized to tray when starting which I didn't see in 1.29. (The effect it had was that Komorebi was showing an empty space for a minimized window) 

I took the liberty to add a `tray_and_multi_window` rule to fix that in a separate commit, hopefully that's cool and not making the PR do too many things. 

I tested both on my machine with latest Unity and it seems to be working, 