### PR TITLE
Add UniGetUI tray rule

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1671,6 +1671,15 @@
       }
     ]
   },
+  "UniGetUI": {
+    "tray_and_multi_window": [
+      {
+        "kind": "Exe",
+        "id": "UniGetUI.exe",
+        "matching_strategy": "Equals"
+      }
+    ]
+  },
   "Unity Editor": {
     "transparency_ignore": [
       {

--- a/applications.yaml
+++ b/applications.yaml
@@ -1288,6 +1288,13 @@
     matching_strategy: Equals
   options:
   - tray_and_multi_window
+- name: UniGetUI
+  identifier:
+    kind: Exe
+    id: UniGetUI.exe
+    matching_strategy: Equals
+  options:
+  - tray_and_multi_window
 - name: Unity Hub
   identifier:
     kind: Exe


### PR DESCRIPTION
WinGetUI rebranded to UniGetUI, so the old WinGetUI rules no longer apply. This copies the old rules, changing the name.

The old `applications.yaml` has two rules with different capitalization, which I did not include.

- [ ] I have formatted `applications.yaml` with `komorebic fmt-asc`.
^ this causes a big diff with unrelated changes (82+ 82-)