### PR TITLE
ignore rules for Microsoft Visual Studio Community 2022

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 overrides.yaml
 /.vscode
+/.vs

--- a/applications.json
+++ b/applications.json
@@ -1902,9 +1902,50 @@
       },
       {
         "kind": "Class",
-        "id": "WindowsForms10.Window.8.app.0.13fa1bf_r22_ad1",
+        "id": "WindowsForms10.Window",
+        "matching_strategy": "StartsWith"
+      },
+      {
+        "kind": "Title",
+        "id": "WindowsFormsParkingWindow",
         "matching_strategy": "Equals"
-      }
+      },
+      [
+        {
+          "kind": "Exe",
+          "id": "devenv.exe",
+          "matching_strategy": "Equals"
+        },
+        {
+          "kind": "Title",
+          "id": "Move files to a new location?",
+          "matching_strategy": "Equals"
+        }
+      ],
+      [
+        {
+          "kind": "Exe",
+          "id": "devenv.exe",
+          "matching_strategy": "Equals"
+        },
+        {
+          "kind": "Title",
+          "id": "QuickWatch",
+          "matching_strategy": "Equals"
+        }
+      ],
+      [
+        {
+          "kind": "Exe",
+          "id": "devenv.exe",
+          "matching_strategy": "Equals"
+        },
+        {
+          "kind": "Title",
+          "id": " - Microsoft Visual Studio",
+          "matching_strategy": "DoesNotEndWith"
+        }
+      ]
     ]
   },
   "Voice.ai": {


### PR DESCRIPTION
@LGUG2Z I have expanded on the ignore rules for `Visual Studio`.

I am not 100% sure if the composite rules need to include the match on `Exe`

```json
{
  "kind": "Exe",
  "id": "devenv.exe",
  "matching_strategy": "Equals"
}
```

But let's see what you say 🤔 
