### PR TITLE
revised rules for Microsoft Visual Studio Community 2022

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1937,11 +1937,18 @@
         "id": "VsDebugConsole.exe",
         "matching_strategy": "Equals"
       },
-      {
-        "kind": "Class",
-        "id": "WindowsForms10.Window",
-        "matching_strategy": "StartsWith"
-      },
+      [
+        {
+          "kind": "Exe",
+          "id": "devenv.exe",
+          "matching_strategy": "Equals"
+        },
+        {
+          "kind": "Class",
+          "id": "WindowsForms10.Window",
+          "matching_strategy": "StartsWith"
+        }
+      ],     
       {
         "kind": "Title",
         "id": "WindowsFormsParkingWindow",


### PR DESCRIPTION
changing rule to composite due to conflict with Remote Desktop Manager as [requested](https://github.com/LGUG2Z/komorebi-application-specific-configuration/pull/115#discussion_r1831639545)