### PR TITLE
revised ignore rule for Visual studio

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1957,7 +1957,7 @@
           "id": "WindowsForms10.Window",
           "matching_strategy": "StartsWith"
         }
-      ],     
+      ],
       {
         "kind": "Title",
         "id": "WindowsFormsParkingWindow",
@@ -1975,18 +1975,11 @@
           "matching_strategy": "Equals"
         }
       ],
-      [
-        {
-          "kind": "Title",
-          "id": "Microsoft Visual Studio",
-          "matching_strategy": "Equals"
-        },
-        {
-          "kind": "Exe",
-          "id": "ServiceHub.ThreadedWaitDialog.exe",
-          "matching_strategy": "Equals"
-        }
-      ]
+      {
+        "kind": "Exe",
+        "id": "ServiceHub.ThreadedWaitDialog.exe",
+        "matching_strategy": "Equals"
+      }
     ]
   },
   "Voice.ai": {


### PR DESCRIPTION
@LGUG2Z This VS is keep on giving. I decided to make a composite rule to be single rule, because the Title was different and it probably fine to ignore a `ServiceHub.ThreadedWaitDialog.exe` anyway.

This is it, for sure.