### PR TITLE
typo in composite rule - visual studio

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1635,6 +1635,15 @@
       }
     ]
   },
+  "TeraCopy": {
+    "ignore": [
+      {
+        "kind": "Exe",
+        "id": "TeraCopy.exe",
+        "matching_strategy": "Equals"
+      }
+    ]
+  },
   "TickTick": {
     "tray_and_multi_window": [
       {

--- a/applications.json
+++ b/applications.json
@@ -1937,11 +1937,18 @@
         "id": "VsDebugConsole.exe",
         "matching_strategy": "Equals"
       },
-      {
-        "kind": "Class",
-        "id": "WindowsForms10.Window",
-        "matching_strategy": "StartsWith"
-      },
+      [
+        {
+          "kind": "Exe",
+          "id": "devenv.exe",
+          "matching_strategy": "Equals"
+        },
+        {
+          "kind": "Class",
+          "id": "WindowsForms10.Window",
+          "matching_strategy": "StartsWith"
+        }
+      ],     
       {
         "kind": "Title",
         "id": "WindowsFormsParkingWindow",

--- a/applications.json
+++ b/applications.json
@@ -1949,7 +1949,7 @@
       [
         {
           "kind": "Exe",
-          "id": "devenv.exe",
+          "id": "iisexpresstray.exe",
           "matching_strategy": "Equals"
         },
         {

--- a/applications.json
+++ b/applications.json
@@ -1957,7 +1957,7 @@
           "id": "WindowsForms10.Window",
           "matching_strategy": "StartsWith"
         }
-      ],     
+      ],
       {
         "kind": "Title",
         "id": "WindowsFormsParkingWindow",
@@ -1975,18 +1975,11 @@
           "matching_strategy": "Equals"
         }
       ],
-      [
-        {
-          "kind": "Title",
-          "id": "Microsoft Visual Studio",
-          "matching_strategy": "Equals"
-        },
-        {
-          "kind": "Exe",
-          "id": "ServiceHub.ThreadedWaitDialog.exe",
-          "matching_strategy": "Equals"
-        }
-      ]
+      {
+        "kind": "Exe",
+        "id": "ServiceHub.ThreadedWaitDialog.exe",
+        "matching_strategy": "Equals"
+      }
     ]
   },
   "Voice.ai": {


### PR DESCRIPTION
This change is correcting a typo on a composite rule for visual studio
