### PR TITLE
feat(apps): add goland rules similar to other jetbrains IDEs

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -643,6 +643,29 @@
       }
     ]
   },
+  "GoLand": {
+    "ignore": [
+      {
+        "kind": "Class",
+        "id": "SunAwtDialog",
+        "matching_strategy": "Equals"
+      }
+    ],
+    "tray_and_multi_window": [
+      {
+        "kind": "Exe",
+        "id": "goland64.exe",
+        "matching_strategy": "Equals"
+      }
+    ],
+    "object_name_change": [
+      {
+        "kind": "Exe",
+        "id": "goland64.exe",
+        "matching_strategy": "Equals"
+      }
+    ]
+  },
   "Golden Dict": {
     "tray_and_multi_window": [
       {


### PR DESCRIPTION
As described in #127 , this adds ignore rules for GoLand, in similar fashion to other jetbrains IDEs
