### PR TITLE
Fix some popup window issues with acad.exe

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -168,6 +168,18 @@
           "id": "acad.exe",
           "matching_strategy": "Equals"
         }
+      ],
+      [
+        {
+          "kind": "Class",
+          "id": "WindowsForms10.Window",
+          "matching_strategy": "StartsWith"
+        },
+        {
+          "kind": "Exe",
+          "id": "acad.exe",
+          "matching_strategy": "Equals"
+        }
       ]
     ]
   },


### PR DESCRIPTION
This might fix some popup window issues like calc and export utility present in acad.exe programs like AutoCAD and Civil3D.