### PR TITLE
add LibreOffice config

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -844,6 +844,15 @@
       }
     ]
   },
+  "LibreOffice": {
+    "object_name_change": [
+      {
+        "kind": "Exe",
+        "id": "soffice.bin",
+        "matching_strategy": "Equals"
+      }
+    ]
+  },
   "Line": {
     "floating": [
       {


### PR DESCRIPTION
LibreOffice apps apparently do not emit `Show` events when starting, only `ObjectNameChange` events. So this config should make them able to be tiled by komorebi.

<!--
  Please follow the Conventional Commits specification.
  By opening this PR, you confirm that you have already searched for similar existing issues/PRs.
  Provide a general summary of your changes below and tick the boxes that apply to the checklist.
-->
