### PR TITLE
fix: add missing hardcoded defaults

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -134,6 +134,15 @@
       }
     ]
   },
+  "ApplicationFrameHost": {
+    "tray_and_multi_window": [
+      {
+        "kind": "Exe",
+        "id": "ApplicationFrameHost.exe",
+        "matching_strategy": "Equals"
+      }
+    ]
+  },
   "ArmCord": {
     "tray_and_multi_window": [
       {
@@ -1198,6 +1207,13 @@
         "id": "firefox.exe",
         "matching_strategy": "Equals"
       }
+    ],
+    "slow_application": [
+      {
+        "kind": "Exe",
+        "id": "firefox.exe",
+        "matching_strategy": "Equals"
+      }
     ]
   },
   "NZXT CAM": {
@@ -1663,6 +1679,20 @@
     ]
   },
   "Steam": {
+    "layered": [
+      {
+        "kind": "Exe",
+        "id": "steam.exe",
+        "matching_strategy": "Equals"
+      }
+    ],
+    "tray_and_multi_window": [
+      {
+        "kind": "Exe",
+        "id": "steam.exe",
+        "matching_strategy": "Equals"
+      }
+    ],
     "ignore": [
       [
         {
@@ -2245,6 +2275,13 @@
     ]
   },
   "Windows Explorer": {
+    "tray_and_multi_window": [
+      {
+        "kind": "Exe",
+        "id": "explorer.exe",
+        "matching_strategy": "Equals"
+      }
+    ],
     "ignore": [
       {
         "kind": "Class",
@@ -2386,6 +2423,15 @@
       }
     ]
   },
+  "komorebi-bar": {
+    "ignore": [
+      {
+        "kind": "Exe",
+        "id": "komorebi-bar.exe",
+        "matching_strategy": "Equals"
+      }
+    ]
+  },
   "komorebi-gui": {
     "ignore": [
       {
@@ -2487,6 +2533,22 @@
       {
         "kind": "Class",
         "id": "VISIOA",
+        "matching_strategy": "Equals"
+      }
+    ]
+  },
+  "WSL default ignores": {
+    // mstsc.exe creates these on Windows 11 when a WSL process is launched
+    // https://github.com/LGUG2Z/komorebi/issues/74
+    "ignore": [
+      {
+        "kind": "Class",
+        "id": "OPContainerClass",
+        "matching_strategy": "Equals"
+      },
+      {
+        "kind": "Class",
+        "id": "IHWindowClass",
         "matching_strategy": "Equals"
       }
     ]


### PR DESCRIPTION
@LGUG2Z I'm not sure about those classes for WSL processes... Are you ok with the `WSL default ignores`?

Also why was that `ApplicationFrameHost` hardcoded as `tray_and_multi_window` should that be kept?!

<!--
  Please follow the Conventional Commits specification.
  By opening this PR, you confirm that you have already searched for similar existing issues/PRs.
  Provide a general summary of your changes below and tick the boxes that apply to the checklist.
-->
