### PR TITLE
feat(apps): add notion

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1300,6 +1300,22 @@
       }
     ]
   },
+  "Notion": {
+    "ignore": [
+      {
+        "kind": "Title",
+        "id": "Notion - Command Search",
+        "matching_strategy": "Equals"
+      }
+    ],
+    "tray_and_multi_window": [
+      {
+        "kind": "Exe",
+        "id": "Notion.exe",
+        "matching_strategy": "Equals"
+      }
+    ]
+  },
   "Notion Enhanced": {
     "tray_and_multi_window": [
       {


### PR DESCRIPTION
Support for Official Notion desktop application.

Windows titled `Notion - Command Search` indicate:
- Toggle command search (default: `ctrl+shift+k`)
- Toggle Notion AI (default `ctrl+shift+j`)