### PR TITLE
feat(apps): add ignore rule for vlc

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -2150,6 +2150,18 @@
           "id": "Plugins and extensions",
           "matching_strategy": "Equals"
         }
+      ],
+      [
+        {
+          "kind": "Exe",
+          "id": "vlc.exe",
+          "matching_strategy": "Equals"
+        },
+        {
+          "kind": "Title",
+          "id": "Building font cache",
+          "matching_strategy": "Equals"
+        }
       ]
     ]
   },


### PR DESCRIPTION
added a new ignore rule for a `Building font cache` popup window