### PR TITLE
feat(apps): add ignore rule for lens (kubernetes platform)

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -898,6 +898,22 @@
       }
     ]
   },
+  "Lens": {
+    "ignore": [
+      [
+        {
+          "kind": "Exe",
+          "id": "Lens.exe",
+          "matching_strategy": "Equals"
+        },
+        {
+          "kind": "Title",
+          "id": "Loading",
+          "matching_strategy": "Equals"
+        }
+      ]
+    ]
+  },
   "LibreCAD": {
     "ignore": [
       [


### PR DESCRIPTION
added ignore rule for the startup splash screen of [Lens](https://k8slens.dev/), which is `a Kubernetes platform that provides tools for seamless interaction with Kubernetes clusters, and an environment for secure and effective work.`

![image](https://github.com/user-attachments/assets/d626f8fc-2cbd-4079-aa7e-b5f33be4c8ea)
