### PR TITLE
Add Mod Organizer 2

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -2683,6 +2683,13 @@
     ]
   },
   "Mod Organizer 2": {
+    "manage": [
+      {
+        "kind": "Exe",
+        "id": "modorganizer.exe",
+        "matching_strategy": "Equals"
+      }
+    ],
     "ignore": [
       {
         "kind": "Title",

--- a/applications.json
+++ b/applications.json
@@ -2681,5 +2681,14 @@
         "matching_strategy": "Equals"
       }
     ]
+  },
+  "Mod Organizer 2": {
+    "ignore": [
+      {
+        "kind": "Title",
+        "id": "Extracting files",
+        "matching_strategy": "Equals"
+      }
+    ]
   }
 }

--- a/applications.json
+++ b/applications.json
@@ -2684,16 +2684,18 @@
   },
   "Mod Organizer 2": {
     "ignore": [
-      {
-        "kind": "Exe",
-        "id": "modorganizer.exe",
-        "matching_strategy": "Equals"
-      },
-      {
-        "kind": "Title",
-        "id": "Extracting files",
-        "matching_strategy": "Equals"
-      }
+      [
+        {
+          "kind": "Exe",
+          "id": "ModOrganizer.exe",
+          "matching_strategy": "Equals"
+        },
+        {
+          "kind": "Title",
+          "id": "Extracting files",
+          "matching_strategy": "Equals"
+        }
+      ]
     ]
   }
 }

--- a/applications.json
+++ b/applications.json
@@ -2683,14 +2683,12 @@
     ]
   },
   "Mod Organizer 2": {
-    "manage": [
+    "ignore": [
       {
         "kind": "Exe",
         "id": "modorganizer.exe",
         "matching_strategy": "Equals"
-      }
-    ],
-    "ignore": [
+      },
       {
         "kind": "Title",
         "id": "Extracting files",


### PR DESCRIPTION
Window rule for Mod organizer 2's installation window.

For detailed information and video to demonstrate changes link to issue #165 is below : 
 [Add ignore rule Mod Organizer 2 pop-up installation windows](https://github.com/LGUG2Z/komorebi-application-specific-configuration/issues/165)


Application rule is set for
https://github.com/ModOrganizer2/modorganizer

