### PR TITLE
Add ignore rule for Desktop Mate

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -420,6 +420,15 @@
       }
     ]
   },
+  "DesktopMate": {
+    "ignore": [
+      {
+        "kind": "Exe",
+        "id": "DesktopMate.exe",
+        "matching_strategy": "Equals"
+      }
+    ]
+  },
   "Discord": {
     "tray_and_multi_window": [
       {


### PR DESCRIPTION
[Desktop Mate](https://store.steampowered.com/app/3301060/Desktop_Mate/) adds characters that interact with your desktop and open windows. It works by using a transparent window. When komorebi manages it, it creates a persistent ghost tile for said window and moves the character back to the center of that ghost for one frame whenever the layout changes or permanently in the case of changing workspaces. I opted to ignore it from komorebi instead of marking it as floating since the point is to have an avatar that's always on screen, so making them disappear when changing workspaces mostly defeats the purpose.

I'm matching the exe name since the class is a generic Unity class (`UnityWndClass`).