### PR TITLE
Add float rule for Barrier

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -234,6 +234,15 @@
       ]
     ]
   },
+  "Barrier": {
+    "floating": [
+      {
+        "kind": "Exe",
+        "id": "barrier.exe",
+        "matching_strategy": "Equals"
+      }
+    ]
+  },
   "Beeper": {
     "tray_and_multi_window": [
       {


### PR DESCRIPTION
[Barrier](https://github.com/debauchee/barrier) lets you share a mouse & keyboard between multiple computers. Typically, its windows are not able to be resized. When komorebi force-resizes them, they do *not* scale property, resulting in large amounts of blank space, hidden elements you can no longer see, or multiple elements stacked on top of each other.

Barrier does get minimized to the tray, however, it seemed to be behaving correctly so I didn't add a `tray_and_multi_window` rule. If I should add it anyway, please let me know.

I'm matching the exe name since the class is a generic QT 5 class (`Qt5QWindowIcon`).