### PR TITLE
Add float rule for prime95

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1516,6 +1516,15 @@
       }
     ]
   },
+  "Prime95": {
+    "floating": [
+      {
+        "Kind": "Exe",
+        "id": "prime95.exe",
+        "matching_strategy": "Equals"
+      }
+    ]
+  },
   "Process Hacker": {
     "ignore": [
       {


### PR DESCRIPTION
[Prime95](https://www.mersenne.org/download/) is a tool often used to stress-test CPU and/or memory. When starting a stress test, it creates N "sub-windows" within its primary window, where N is the number of cores you're testing. These windows do not render outside of the primary window. komorebi will try to create new tiles for all of them, meaning you end up with N ghost tiles and the inability to see the contents of any of the windows.

I'm matching the exe name since each worker's title is different, and the class appears to change every time it's opened.