### PR TITLE
Fix schema error in prime95 config

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1537,7 +1537,7 @@
   "Prime95": {
     "floating": [
       {
-        "Kind": "Exe",
+        "kind": "Exe",
         "id": "prime95.exe",
         "matching_strategy": "Equals"
       }


### PR DESCRIPTION
#169 broke the schema with a capital `K` in the `kind` field, causing komorebi to fail to start when loading it.

Apologies for this. I should've spotted it. It seems like there's a few pre-made GitHub actions for validating JSON schema (e.g. [validate-json](https://github.com/marketplace/actions/validate-json)) which could be helpful to avoid this in the future.