### PR TITLE
Add GitHub action for validating JSON schema

### DIFF
--- a/.github/workflows/validate-schema.yaml
+++ b/.github/workflows/validate-schema.yaml
@@ -1,0 +1,19 @@
+name: Validate JSON Schema
+
+on: [push, pull_request]
+
+jobs:
+  validate-json-schema:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Download Schema
+        run: wget https://raw.githubusercontent.com/LGUG2Z/komorebi/refs/heads/master/schema.asc.json
+
+      - name: Validate JSON
+        uses: GrantBirki/json-yaml-validate@v3
+        with:
+          json_schema: schema.asc.json
+          files: application.json

--- a/applications.json
+++ b/applications.json
@@ -1188,8 +1188,6 @@
     ]
   },
   "Microsoft Terminal Services Client": {
-    // mstsc.exe creates these on Windows 11 when a WSL process is launched
-    // https://github.com/LGUG2Z/komorebi/issues/74
     "ignore": [
       {
         "kind": "Class",


### PR DESCRIPTION
Adds a GitHub action that runs on PRs and pushes to validate the `applications.json` schema to avoid issues like #169 caused.

Here's example runs with a valid and invalid schema:
Valid Schema: https://github.com/Insprill/komorebi-application-specific-configuration/actions/runs/13300938984
Invalid Schema: https://github.com/Insprill/komorebi-application-specific-configuration/actions/runs/13300944725

This action also has [the option to comment on PRs](https://github.com/GrantBirki/json-yaml-validate?tab=readme-ov-file#pull-request-comment) with schema violations that I left disabled. I can enable it if you'd like.

I had to remove the comment for `Microsoft Terminal Services Client` since it caused a syntax error while parsing.
