### PR TITLE
Add float rule for Steam's update window

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1850,6 +1850,20 @@
           "matching_strategy": "DoesNotEqual"
         }
       ]
+    ],
+    "floating": [
+      [
+        {
+          "kind": "Exe",
+          "id": "steam.exe",
+          "matching_strategy": "Equals"
+        },
+        {
+          "kind": "Class",
+          "id": "BootstrapUpdateUIClass",
+          "matching_strategy": "Equals"
+        }
+      ]
     ]
   },
   "Steam Beta": {


### PR DESCRIPTION
When Steam's update window gets resized by komorebi, it does not dynamically adjust the contents and instead creates a giant pure-white window.

<details>
<summary>Before</summary>
<img src="https://github.com/user-attachments/assets/fd698a74-c6e7-40e4-82f6-d265fc979fb2"/>
</details>
<details>
<summary>After</summary>
<img src="https://github.com/user-attachments/assets/73ef7f46-dce2-4267-b0dd-18f4fe337c45"/>
</details>