### PR TITLE
Add float rule for the MOTU M-Series software

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1279,6 +1279,15 @@
       }
     ]
   },
+  "MOTU M-Series": {
+    "floating": [
+      {
+        "kind": "Exe",
+        "id": "MOTUMSeries.exe",
+        "matching_strategy": "Equals"
+      }
+    ]
+  },
   "Mozilla Firefox": {
     "ignore": [
       {


### PR DESCRIPTION
MOTU's [software](https://motu.com/en-us/download/#category=1&product=408) for the M-Series audio interfaces does not scale as the window size changes, and instead leaves a large amount of blank space.

<details>
<summary>Before</summary>
<img src="https://github.com/user-attachments/assets/b6dcd1ad-7742-4deb-8542-139cc11bd811"/>
</details>
<details>
<summary>After</summary>
<img src="https://github.com/user-attachments/assets/b34d850c-b2e1-44be-8e4f-d9dab025dcf3"/>
</details>