### PR TITLE
Add float rule for GIMP's "About GIMP" window

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -682,6 +682,18 @@
           "id": "GIMP",
           "matching_strategy": "DoesNotEndWith"
         }
+      ],
+      [
+        {
+          "kind": "Exe",
+          "id": "gimp",
+          "matching_strategy": "StartsWith"
+        },
+        {
+          "kind": "Title",
+          "id": "About GIMP",
+          "matching_strategy": "Equals"
+        }
       ]
     ]
   },


### PR DESCRIPTION
Adds a float rule for GIMP's "About GIMP" window that shows when there's an update or when going to `Help > About GIMP`.
Without this rule, the window contents scale awkwardly at smaller sizes, and it's generally not a window I'd imagine anyone would want to tile.

![image](https://github.com/user-attachments/assets/b675992f-6792-47b2-9d60-99c2d25bcb72)

~~I only included a Title matcher, although I can also match the exe like the other float rule if desired.~~