### PR TITLE
Add float rule for Clumsy

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -354,6 +354,15 @@
       }
     ]
   },
+  "Clumsy": {
+    "floating": [
+      {
+        "kind": "Exe",
+        "id": "clumsy.exe",
+        "matching_strategy": "Equals"
+      }
+    ]
+  },
   "CopyQ": {
     "ignore": [
       {


### PR DESCRIPTION
Adds a float rule for [Clumsy](https://github.com/jagt/clumsy). Clumsy's window normally isn't allowed to be resized. When Clumsy opens, it immediately asks to escalate to admin permissions. Before you accept that, it will take up a tile, which isn't desirable. In that brief time, the window also does not scale, either cutting off contents if it's too small, or ending up with a large amount of white space if it's too large.