### PR TITLE
Add float rule for Prism Launcher's popup windows

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1587,6 +1587,22 @@
       }
     ]
   },
+  "Prism Launcher": {
+    "floating": [
+      [
+        {
+          "kind": "Exe",
+          "id": "prismlauncher.exe",
+          "matching_strategy": "Equals"
+        },
+        {
+          "kind": "Title",
+          "id": "- Prism Launcher",
+          "matching_strategy": "Contains"
+        }
+      ]
+    ]
+  },
   "Process Hacker": {
     "ignore": [
       {


### PR DESCRIPTION
[Prism Launcher](https://prismlauncher.org/) has several popup windows (general settings, instance settings, account management) all of which have a minimum size that they will *not* scale below. This minimum size is fairly large, so once komorebi tries to tile it with more than three other windows open simultaneously (on my 21:9 monitor) they will start overlapping other applications, or render off-screen.

Other popups also have a maximum size that they will *not* scale above, like the progress dialog when downloading a new version. This will result in a tile with huge margins.

I chose the matcher as anything containing `- Prism Launcher` since the normal Prism Launcher window title is `Prism Launcher 8.3` (`8.3` is the version), and all popup windows have the title `XYZ - Prism Launcher 8.3`. I played around a bit and didn't find any false matches, or missed popups.

I'd prefer if the main window always floated too, but I felt that may be too opinionated a change, considering functionally there's nothing wrong.