### PR TITLE
Add object_name_change rule for VLC

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -2188,6 +2188,13 @@
     ]
   },
   "VLC": {
+    "object_name_change": [
+      {
+        "kind": "Exe",
+        "id": "vlc.exe",
+        "matching_strategy": "Equals"
+      }
+    ],
     "ignore": [
       [
         {


### PR DESCRIPTION
When opening a video in VLC from file explorer, the window will resize to fit the content. Depending on your tiling layout, this causes most of VLC to be off-screen or covering other tiles. Anything that updates the window size or position (manually or from komorebi) will snap it back into its tile, but it won't happen automatically.

Adding an `object_name_change` rule fixes this, although it does introduce two small quirks. The first is how long it takes before it snaps into its tile. This can be seen in the After video below. The second is, if you fullscreen the window with komorebi after VLC opens, but before it starts playing the content (this is surprisingly easy to do), you'll fullscreen a blank "VLC (Direct3D11 output)" window which will then persist until it, or VLC, is closed.

I initially tried this fix with the `slow_application` rule, however, even with a large `slow_application_compensation_time`, VLC would still not respect its tile. I don't know if this issue is fixable in Komorebi without the need for a window rule. If so, it would be nice to avoid the downsides listed above, but until then, I'd say this is better than the previous behaviour.

I tested the popup windows we also have rules for and this does not negatively effect them.

<details>
<summary>Before</summary>

https://github.com/user-attachments/assets/bdcf714d-b044-4a62-9a1a-e4f118812264

</details>

<details>
<summary>After</summary>

https://github.com/user-attachments/assets/db002157-f812-43bc-8135-8bd0026eebb1

</details>


