### PR TITLE
Fix VLC ignore rule missing the preferences window

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -2222,7 +2222,7 @@
         {
           "kind": "Title",
           "id": "Preferences",
-          "matching_strategy": "Equals"
+          "matching_strategy": "Contains"
         }
       ],
       [


### PR DESCRIPTION
VLC's preferences window is named either "Simple Preferences" or "Advanced Preferences" depending on which mode you're in. The current matcher was checking if it was *equal* to "Preferences", which unless there's some secret preferences window I'm unaware of, is never the case.

![image](https://github.com/user-attachments/assets/205aeee2-d101-4f17-90d8-29450bc0f6d0)

![image](https://github.com/user-attachments/assets/64579457-1c26-4860-b235-6eec0309c46d)
