### PR TITLE
Adobe Photoshop PSDiagBox ignore rule

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -32,6 +32,15 @@
       }
     ]
   },
+  "Adobe Photshop": {
+    "ignore": [
+      {
+        "kind": "Class",
+        "id": "PSDialogBox",
+        "matching_strategy": "Equals"
+      }
+    ]
+  },
   "Adobe Premiere Pro": {
     "ignore": [
       {


### PR DESCRIPTION
PR for  #164 -- sorry for the delay. 

Adds an ignore rule for Photoshop's dialog boxes. 