### PR TITLE
Add Ignore Rule: All Ableton Sub-Windows

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -20,7 +20,19 @@
         "kind": "Class",
         "id": "Vst3PlugWindow",
         "matching_strategy": "Legacy"
-      }
+      },
+      [
+        {
+          "kind": "Class",
+          "id": "Ableton Live Window Class",
+          "matching_strategy": "Equals"
+        },
+        {
+          "kind": "Title",
+          "id": "Ableton",
+          "matching_strategy": "DoesNotContain"
+        }
+      ]
     ]
   },
   "Adobe Creative Cloud": {


### PR DESCRIPTION
PR for #163. Took your advice and created a composite rule for ALL `"class": "Ableton Live Window Class"` that don't match "Ableton" in the title. 

This seems to take care of all Ableton-native sub-windows including export settings, export progress bar, AND the settings window, while still keeping the main Ableton window managed. Other rules for plugins etc. have a different class, so their rules were kept as-is. 

This way, all Ableton versions should work. I couldn't find any sub-windows that have Ableton in the title, so this is the best solution I see here for now. 

Tested on Komorebic 0.1.34 with Ableton Live 12.1.5. 