### PR TITLE
Add: Powertoys - File Locksmith

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -44,7 +44,7 @@
       }
     ]
   },
-  "Adobe Photshop": {
+  "Adobe Photoshop": {
     "ignore": [
       {
         "kind": "Class",
@@ -1655,6 +1655,11 @@
       {
         "kind": "Exe",
         "id": "PowerToys.AdvancedPaste.exe",
+        "matching_strategy": "Equals"
+      },
+	  {
+        "kind": "Exe",
+        "id": "PowerToys.FileLocksmithUI.exe",
         "matching_strategy": "Equals"
       }
     ]


### PR DESCRIPTION
Adds Powertoys File Locksmith and it joins its sibling in being harmoniously ignored for the benefit of us all as it does not play well with Komorebi and starts as a frozen window without this rule in my personal experience.

<!--
  Please follow the Conventional Commits specification.
  By opening this PR, you confirm that you have already searched for similar existing issues/PRs.
  Provide a general summary of your changes below and tick the boxes that apply to the checklist.
-->
