### PR TITLE
Add ignore rule for Dell Display Manager

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -486,6 +486,15 @@
       }
     ]
   },
+  "Dell Display Manager": {
+    "ignore": [
+      {
+        "kind": "Exe",
+        "id": "DDM.exe",
+        "matching_strategy": "Equals"
+      }
+    ]
+  },
   "Delphi applications": {
     "ignore": [
       {


### PR DESCRIPTION
Following #211

Ignore rule:
* Dell Display Manager (`DDM.exe`)

Ran `just sort` as described in the contribution section of the readme.