### PR TITLE
Akiflow: ignore the CLI overlay window

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -111,6 +111,20 @@
     ]
   },
   "Akiflow": {
+    "ignore": [
+      [
+        {
+          "kind": "Exe",
+          "id": "Akiflow.exe",
+          "matching_strategy": "Equals"
+        },
+        {
+          "kind": "Title",
+          "id": "Akiflow - Cli",
+          "matching_strategy": "Equals"
+        }
+      ]
+    ],
     "tray_and_multi_window": [
       {
         "kind": "Exe",


### PR DESCRIPTION
Akiflow has a spotlight-like "Cli" overlay panel that users toggle with a keyboard shortcut to quickly record tasks. Without this rule, komorebi manages the overlay as a regular tiled window, resizing and placing it into the layout.

The overlay shares the same executable (`Akiflow.exe`) and window class (`Chrome_WidgetWin_1`) as the main Akiflow window. The distinguishing factor is the window title:

- Main window: `Akiflow`
- Overlay panel: `Akiflow - Cli`

A composite rule matching both Exe and Title is used to narrowly target the overlay without affecting the main window.

Using `ignore` rather than `floating` is consistent with how other spotlight-like overlays are handled in this repository (e.g. ueli, PowerToys Run, CopyQ, 1Password, Notion's Command Search).

```
title: Akiflow - Cli, exe: Akiflow.exe, class: Chrome_WidgetWin_1
```