### PR TITLE
Claude: add layered application rule

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -393,6 +393,15 @@
       }
     ]
   },
+  "Claude": {
+    "layered": [
+      {
+        "kind": "Exe",
+        "id": "claude.exe",
+        "matching_strategy": "Equals"
+      }
+    ]
+  },
   "Clementine": {
     "tray_and_multi_window": [
       {


### PR DESCRIPTION
The Claude desktop app (Electron-based) uses the `WS_EX_LAYERED` extended window style. Without this rule, komorebi does not manage the window.

This is consistent with how other Electron apps are handled (Discord, Zed).