### PR TITLE
Added floating rule for Anki's popup windows

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -144,6 +144,25 @@
         "id": "anki.exe",
         "matching_strategy": "Equals"
       }
+    ],
+    "floating": [
+      [
+        {
+          "kind": "Class",
+          "id": "Qt691QWindowIcon",
+          "matching_strategy": "Equals"
+        },
+        {
+          "kind": "Exe",
+          "id": "pythonw.exe",
+          "matching_strategy": "Equals"
+        },
+        {
+          "kind": "Title",
+          "id": "- Anki",
+          "matching_strategy": "DoesNotEndWith"
+        }
+      ]
     ]
   },
   "ApplicationFrameHost": {


### PR DESCRIPTION
Following #220 

Anki's pop up windows should be treated as floating instead of tiled
